### PR TITLE
safe_url_string: encode | and % in userinfo

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -303,6 +303,47 @@ class UrlTests(unittest.TestCase):
             "http://www.example.com/path/to/%23/foo/bar?url=http%3A%2F%2Fwww.example.com%2F%2Fpath%2Fto%2F%23%2Fbar%2Ffoo#frag",
         )
 
+    def test_safe_url_string_encode_idna_domain_with_port(self):
+        self.assertEqual(
+            safe_url_string("http://新华网.中国:80"), "http://xn--xkrr14bows.xn--fiqs8s:80"
+        )
+
+    def test_safe_url_string_encode_idna_domain_with_username_password_and_port_number(
+        self,
+    ):
+        self.assertEqual(
+            safe_url_string("ftp://admin:admin@新华网.中国:21"),
+            "ftp://admin:admin@xn--xkrr14bows.xn--fiqs8s:21",
+        )
+        self.assertEqual(
+            safe_url_string("http://Åsa:abc123@➡.ws:81/admin"),
+            "http://%C3%85sa:abc123@xn--hgi.ws:81/admin",
+        )
+        self.assertEqual(
+            safe_url_string("http://japão:não@️i❤️.ws:8000/"),
+            "http://jap%C3%A3o:n%C3%A3o@xn--i-7iq.ws:8000/",
+        )
+
+    def test_safe_url_string_encode_idna_domain_with_username_and_empty_password_and_port_number(
+        self,
+    ):
+        self.assertEqual(
+            safe_url_string("ftp://admin:@新华网.中国:21"),
+            "ftp://admin:@xn--xkrr14bows.xn--fiqs8s:21",
+        )
+        self.assertEqual(
+            safe_url_string("ftp://admin@新华网.中国:21"),
+            "ftp://admin@xn--xkrr14bows.xn--fiqs8s:21",
+        )
+
+    def test_safe_url_string_userinfo_unsafe_chars(
+        self,
+    ):
+        self.assertEqual(
+            safe_url_string("ftp://admin:|%@example.com"),
+            "ftp://admin:%7C%25@example.com",
+        )
+
     def test_safe_download_url(self):
         self.assertEqual(
             safe_download_url("http://www.example.org"), "http://www.example.org/"
@@ -1095,39 +1136,6 @@ class DataURITests(unittest.TestCase):
         self.assertEqual(result.data, b"A brief note")
         result = parse_data_uri("DaTa:,A%20brief%20note")
         self.assertEqual(result.data, b"A brief note")
-
-    def test_safe_url_string_encode_idna_domain_with_port(self):
-        self.assertEqual(
-            safe_url_string("http://新华网.中国:80"), "http://xn--xkrr14bows.xn--fiqs8s:80"
-        )
-
-    def test_safe_url_string_encode_idna_domain_with_username_password_and_port_number(
-        self,
-    ):
-        self.assertEqual(
-            safe_url_string("ftp://admin:admin@新华网.中国:21"),
-            "ftp://admin:admin@xn--xkrr14bows.xn--fiqs8s:21",
-        )
-        self.assertEqual(
-            safe_url_string("http://Åsa:abc123@➡.ws:81/admin"),
-            "http://%C3%85sa:abc123@xn--hgi.ws:81/admin",
-        )
-        self.assertEqual(
-            safe_url_string("http://japão:não@️i❤️.ws:8000/"),
-            "http://jap%C3%A3o:n%C3%A3o@xn--i-7iq.ws:8000/",
-        )
-
-    def test_safe_url_string_encode_idna_domain_with_username_and_empty_password_and_port_number(
-        self,
-    ):
-        self.assertEqual(
-            safe_url_string("ftp://admin:@新华网.中国:21"),
-            "ftp://admin@xn--xkrr14bows.xn--fiqs8s:21",
-        )
-        self.assertEqual(
-            safe_url_string("ftp://admin@新华网.中国:21"),
-            "ftp://admin@xn--xkrr14bows.xn--fiqs8s:21",
-        )
 
 
 if __name__ == "__main__":

--- a/w3lib/url.py
+++ b/w3lib/url.py
@@ -55,6 +55,7 @@ EXTRA_SAFE_CHARS = b"|"  # see https://github.com/scrapy/w3lib/pull/25
 
 _safe_chars = RFC3986_RESERVED + RFC3986_UNRESERVED + EXTRA_SAFE_CHARS + b"%"
 _path_safe_chars = _safe_chars.replace(b"#", b"")
+RFC3986_USERINFO_SAFE_CHARS = RFC3986_UNRESERVED + RFC3986_SUB_DELIMS + b":"
 
 _ascii_tab_newline_re = re.compile(
     r"[\t\n\r]"
@@ -95,33 +96,34 @@ def safe_url_string(
     decoded = to_unicode(url, encoding=encoding, errors="percentencode")
     parts = urlsplit(_ascii_tab_newline_re.sub("", decoded))
 
-    username, password, hostname, port_number = (
+    username, password, hostname, port = (
         parts.username,
         parts.password,
         parts.hostname,
         parts.port,
     )
     netloc_bytes = b""
-
-    # IDNA encoding can fail for too long labels (>63 characters)
-    # or missing labels (e.g. http://.example.com)
-    try:
-        # When we have hostname we use it instead of netloc directly
-        if hostname:
-            if isinstance(username, str):
-                netloc_bytes += quote(username, _safe_chars).encode(encoding)
-                if isinstance(password, str) and password:
-                    netloc_bytes += f":{quote(password, _safe_chars)}".encode(encoding)
-                netloc_bytes += b"@"
+    if username is not None or password is not None:
+        if username is not None:
+            safe_username = quote(username, RFC3986_USERINFO_SAFE_CHARS)
+            netloc_bytes += safe_username.encode(encoding)
+        if password is not None:
+            netloc_bytes += b":"
+            safe_password = quote(password, RFC3986_USERINFO_SAFE_CHARS)
+            netloc_bytes += safe_password.encode(encoding)
+        netloc_bytes += b"@"
+    if hostname is not None:
+        try:
             netloc_bytes += hostname.encode("idna")
-            if port_number:
-                netloc_bytes += f":{port_number}".encode(encoding)
-        else:
-            netloc_bytes = parts.netloc.encode("idna")
-    except UnicodeError:
-        netloc = parts.netloc
-    else:
-        netloc = netloc_bytes.decode()
+        except UnicodeError:
+            # IDNA encoding can fail for too long labels (>63 characters) or
+            # missing labels (e.g. http://.example.com)
+            netloc_bytes += hostname.encode(encoding)
+    if port is not None:
+        netloc_bytes += b":"
+        netloc_bytes += str(port).encode(encoding)
+
+    netloc = netloc_bytes.decode()
 
     # default encoding for path component SHOULD be UTF-8
     if quote_path:
@@ -132,7 +134,7 @@ def safe_url_string(
     return urlunsplit(
         (
             parts.scheme,
-            netloc.rstrip(":"),
+            netloc,
             path,
             quote(parts.query.encode(encoding), _safe_chars),
             quote(parts.fragment.encode(encoding), _safe_chars),


### PR DESCRIPTION
- Defined an `RFC3986_USERINFO_SAFE_CHARS` constant based on the [specification](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.1), and used it for the encoding of username and password.
- Restricted the try-except to a single line that may raise an exception.
- Removed `.rstrip(":")`, making it unnecessary with the new way the port is encoded (if there is no port, `:` is not appended to the hostname in the first place).
- Moved the tests right after pre-existing tests of the `safe_url_string` function. Before they were in an unrelated test case class about data URIs.